### PR TITLE
footer.html: fix link to bylaws

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,7 +19,7 @@
             {% endif %}
             <li>. <a href="/feed.xml">news via RSS</a></li>
 	    <li>. <a href="https://portal.isoc.org/join/chapter">join the CNSIG</a></li>
-	    <li>. <a href="assets/CNSIG-Bylaws_v1.1.pdf">CNSIG Bylaws</a></li>
+	    <li>. <a href="/assets/CNSIG-Bylaws_v1.1.pdf">CNSIG Bylaws</a></li>
         </ul>
         {%- include social.html -%}
       </div>


### PR DESCRIPTION
Changing link to bylaws to an absolute path.

Current link is a relative link, when accessed from anywhere but the homepage
it will end in a 404. IE: from http://cnsig.info/about/ it links to
http://cnsig.info/about/assets/CNSIG-Bylaws_v1.1.pdf (404)
Added slash makes sure it will always link to
http://cnsig.info/assets/CNSIG-Bylaws_v1.1.pdf